### PR TITLE
Add tab bar and penalties screen

### DIFF
--- a/Principles/App/MainTabBarController.swift
+++ b/Principles/App/MainTabBarController.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+final class MainTabBarController: UITabBarController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        viewControllers = [
+            makeNav(for: PrinciplesViewController(), title: "Principles", image: "list.bullet"),
+            makeNav(for: CalendarViewController(), title: "Calendar", image: "calendar"),
+            makeNav(for: PenaltiesViewController(), title: "Penalties", image: "exclamationmark.circle")
+        ]
+    }
+
+    private func makeNav(for root: UIViewController, title: String, image: String) -> UINavigationController {
+        root.title = title
+        let nav = UINavigationController(rootViewController: root)
+        nav.tabBarItem.title = title
+        nav.tabBarItem.image = UIImage(systemName: image)
+        return nav
+    }
+}

--- a/Principles/App/SceneDelegate.swift
+++ b/Principles/App/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		guard let windowScene = (scene as? UIWindowScene) else { return }
 		window = UIWindow(frame: windowScene.coordinateSpace.bounds)
 		window?.windowScene = windowScene
-		window?.rootViewController = ViewController()
+        window?.rootViewController = MainTabBarController()
 		window?.makeKeyAndVisible()
 	}
 

--- a/Principles/CalendarScreen/CalendarViewController.swift
+++ b/Principles/CalendarScreen/CalendarViewController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+final class CalendarViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = "Calendar"
+    }
+}

--- a/Principles/Entities/Penalty.swift
+++ b/Principles/Entities/Penalty.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 struct Penalty: Identifiable {
-	let id: UUID
-	let action: String
-	let cause: String
+    let id: UUID
+    /// Short description of the penalty.
+    let title: String
+    /// Date when the penalty occurred.
+    let date: Date
+    /// Name of the principle which this penalty relates to.
+    let principleTitle: String
 }

--- a/Principles/PenaltiesScreen/PenaltiesViewController.swift
+++ b/Principles/PenaltiesScreen/PenaltiesViewController.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+final class PenaltiesViewController: UIViewController {
+    private let tableView = UITableView()
+    private var penalties: [Penalty] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = "Penalties"
+        configureTableView()
+        loadSampleData()
+    }
+
+    private func configureTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.register(PenaltyCell.self, forCellReuseIdentifier: PenaltyCell.reuseIdentifier)
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func loadSampleData() {
+        // Sample data for demonstration purposes
+        penalties = [
+            Penalty(id: UUID(), title: "Missed deadline", date: Date(), principleTitle: "Discipline"),
+            Penalty(id: UUID(), title: "Late submission", date: Date().addingTimeInterval(-86400), principleTitle: "Punctuality")
+        ]
+    }
+}
+
+extension PenaltiesViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        penalties.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: PenaltyCell.reuseIdentifier, for: indexPath) as? PenaltyCell else {
+            return UITableViewCell()
+        }
+        cell.configure(with: penalties[indexPath.row])
+        return cell
+    }
+}

--- a/Principles/PenaltiesScreen/PenaltyCell.swift
+++ b/Principles/PenaltiesScreen/PenaltyCell.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+final class PenaltyCell: UITableViewCell {
+    static let reuseIdentifier = "PenaltyCell"
+
+    private let titleLabel = UILabel()
+    private let dateLabel = UILabel()
+    private let principleLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with penalty: Penalty) {
+        titleLabel.text = penalty.title
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        dateLabel.text = formatter.string(from: penalty.date)
+        principleLabel.text = penalty.principleTitle
+    }
+
+    private func setup() {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, dateLabel, principleLabel])
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+        ])
+    }
+}

--- a/Principles/PrinciplesScreen/PrinciplesViewController.swift
+++ b/Principles/PrinciplesScreen/PrinciplesViewController.swift
@@ -1,9 +1,11 @@
 import UIKit
 
 final class PrinciplesViewController: UIViewController {
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-	}
-	
+
+        override func viewDidLoad() {
+                super.viewDidLoad()
+                view.backgroundColor = .systemBackground
+                title = "Principles"
+        }
+
 }


### PR DESCRIPTION
## Summary
- create tab bar with `Principles`, `Calendar`, and `Penalties` sections
- implement basic `CalendarViewController`
- add penalties list UI with sample data
- extend `Penalty` entity with title, date and related principle information

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684805dd43208333b653b4817010120c